### PR TITLE
Fix eth1

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -5,3 +5,11 @@
 
 yum -y install vim
 
+if [ -f /etc/sysconfig/network-scripts/ifcfg-eth1 ] ; then
+    sed -i \
+        -e '/^NM_CONTROLLED=/d;$aNM_CONTROLLED=yes' \
+        -e '/^BOOTPROTO=/d;$aBOOTPROTO=static' \
+        /etc/sysconfig/network-scripts/ifcfg-eth1
+    /sbin/ifdown eth1
+    /sbin/ifup eth1
+fi


### PR DESCRIPTION
Prior to this change, eth1 is not activated (at least on current CentOS), meaning we don't have a known static IP address.