### PR TITLE
(#23) Wait for server before running agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following environment variables are used to configure the Vagrant environmen
 | Environment variable | Default value          | Description                            |
 | -------------------- | -------------          | -----------                            |
 | `IP_SUBNET`          | `192.168.32`           | The internal IP subnet used by Vagrant |
+| `PUPPET_VERSION`     | none (use the latest)  | The Puppet agent version               |
 | `PUPPET_RELEASE`     | `6`                    | The Puppet major release version       |
 | `EL_RELEASE`         | `7`                    | The EL release of the base box         |
 | `BOX`                | `centos/${EL_RELEASE}` | The base box name                      |

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,6 +3,7 @@
 puppet_release="$1"
 el_release="$2"
 ip_subnet="$3"
+puppet_version="$4"
 
 if [ -f /etc/sysconfig/network-scripts/ifcfg-eth1 ] ; then
     sed -i \
@@ -17,7 +18,11 @@ release_url="http://yum.puppet.com/puppet${puppet_release}-release-el-${el_relea
 
 yum -y install $release_url --nogpgcheck
 
-yum -y install puppet-agent
+if [ -n "$puppet_version" ] ; then
+    yum -y install puppet-agent-"$puppet_version"
+else
+    yum -y install puppet-agent
+fi
 
 # Source the profile to get the path
 . /etc/profile.d/puppet-agent.sh

--- a/scripts/puppet_install.sh
+++ b/scripts/puppet_install.sh
@@ -15,6 +15,7 @@ if [ "$( facter os.release.major )" -gt 7 ] ; then
 fi
 
 # Bootstrap the puppet module configuration
-puppet module install puppet/r10k
+puppet module install puppet-r10k
+puppet module install puppetlabs-git
 puppet apply /vagrant/bootstrap.pp
 puppet apply -e 'include ["puppetserver", "profile::puppetserver::config"]'


### PR DESCRIPTION
* Add a check for connectivity (and a sleep loop) before running the
  agent
* Add `PUPPET_VERSION` environment variable to allow specifying the
  version of the `puppet-agent` package to install
* Explicitly install puppetlabs-git since it is no longer a dependency
  of puppet-r10k

- Fixes #23