### PR TITLE
Various updates

### DIFF
--- a/Boltdir/Puppetfile
+++ b/Boltdir/Puppetfile
@@ -4,10 +4,12 @@
 # The following directive installs modules to the managed moduledir.
 moduledir '.modules'
 
-mod 'puppetlabs/stdlib', '7.1.0'
+mod 'puppet/firewalld', '4.5.1'
+mod 'puppetlabs/stdlib', '8.6.0'
 mod 'puppetlabs/git', '0.5.0'
-mod 'puppet/r10k', '10.0.0'
+mod 'puppet/r10k', '11.0.1'
 mod 'dylanratcliffe/bolt_vagrant', '1.1.0'
-mod 'puppetlabs/ruby', '1.0.1'
-mod 'puppetlabs/inifile', '5.1.0'
-mod 'puppetlabs/vcsrepo', '5.0.0'
+mod 'puppetlabs/inifile', '6.1.0'
+mod 'puppetlabs/vcsrepo', '6.1.0'
+mod 'choria/mcollective', '0.14.4'
+mod 'puppet/systemd', '5.2.0'

--- a/Boltdir/bolt-project.yaml
+++ b/Boltdir/bolt-project.yaml
@@ -6,8 +6,10 @@ modules:
 - name: dylanratcliffe/bolt_vagrant
   version_requirement: 1.1.0
 - name: puppet/r10k
-  version_requirement: 9.0.0
+  version_requirement: 11.0.1
 - name: puppetlabs/git
   version_requirement: 0.5.0
 - name: puppetlabs/stdlib
-  version_requirement: 6.6.0
+  version_requirement: 8.6.0
+- name: puppet/firewalld
+  version_requirement: 4.5.1

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,39 +1,41 @@
 forge "https://forge.puppet.com/"
 
 # stdlib is required by many other modules.
-mod 'puppetlabs-stdlib', '7.1.0'
+mod 'puppetlabs-stdlib', '9.4.0'
 
 # puppetdb is needed in order to use exported resources.
-mod 'puppetlabs-puppetdb', '7.9.0'
+mod 'puppetlabs-puppetdb', '7.13.0'
 
 # These modules are all dependencies for puppetdb.
-mod 'puppetlabs-inifile', '5.1.0'
-mod 'puppetlabs-postgresql', '7.2.0'
-mod 'puppetlabs-concat', '7.0.2'
-mod 'puppetlabs-firewall', '3.0.1'
+mod 'puppetlabs-inifile', '6.1.0'
+mod 'puppetlabs-postgresql', '9.2.0'
+mod 'puppetlabs-concat', '9.0.0'
+mod 'puppetlabs-firewall', '7.0.2'
 
 # r10k gives us dynamic Puppet environments.
-mod 'puppet-r10k', '10.0.0'
+mod 'puppet-r10k', '12.2.0'
 
 # These modules are all dependencies for r10k.
-mod 'puppetlabs-ruby', '1.0.1' # Required by puppet-r10k
-mod 'puppetlabs-vcsrepo', '5.0.0' # Required by puppet-r10k
+mod 'puppetlabs-vcsrepo', '6.1.0' # Required by puppet-r10k
 mod 'puppetlabs-git', '0.5.0' # Required by puppet-r10k
 
 # Enables the EPEL repository on RHEL/CentOS.
-mod 'puppet-epel', '3.0.1'
+mod 'puppet-epel', '5.0.0'
 
 mod 'puppetlabs-puppetserver_gem', '1.1.1' # Required for eyaml.
-mod 'puppetlabs-translate', '2.2.0' # Required by puppetlabs-apt
 
 # mcollective with NATS as message queue
-mod 'choria-mcollective', '0.13.2'
-mod 'choria-mcollective_agent_puppet', '2.4.1'
-mod 'choria-mcollective_agent_package', '5.3.0'
+mod 'choria-mcollective', '0.14.4'
+mod 'choria-mcollective_agent_puppet', '2.4.2'
+mod 'choria-mcollective_agent_package', '5.4.0'
 mod 'choria-mcollective_agent_service', '4.0.1'
 mod 'choria-mcollective_agent_filemgr', '2.0.1'
 mod 'choria-mcollective_util_actionpolicy', '3.2.0'
-mod 'choria-mcollective_choria', '0.21.0'
-mod 'choria-choria', '0.24.0'
+mod 'choria-mcollective_choria', '0.22.0'
+mod 'choria-choria', '0.30.1'
 
-mod 'camptocamp-systemd', '3.0.0'
+mod 'puppet-systemd', '6.0.0'
+mod 'puppetlabs-apt', '9.1.0' # Required by puppetlabs-postgresql, choria-choria
+
+# Manage firewalld
+mod 'puppet-firewalld', '4.5.1'

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ The following environment variables are used to configure the Vagrant environmen
 | -------------------- | -------------          | -----------                            |
 | `IP_SUBNET`          | `192.168.32`           | The internal IP subnet used by Vagrant |
 | `PUPPET_VERSION`     | none (use the latest)  | The Puppet agent version               |
-| `PUPPET_RELEASE`     | `6`                    | The Puppet major release version       |
-| `EL_RELEASE`         | `7`                    | The EL release of the base box         |
-| `BOX`                | `centos/${EL_RELEASE}` | The base box name                      |
+| `PUPPET_RELEASE`     | `7`                    | The Puppet major release version       |
+| `EL_RELEASE`         | `9`                    | The EL release of the base box         |
+| `EL_OS_NAME`         | `centos`               | The base box OS                        |
+| `BOX`                | Depends on EL_OS_NAME  | The base box name                      |
+| `DEBUG`              | not set                | Set to enable debugging output         |
 
 ## See also
 

--- a/site/profile/manifests/puppetserver.pp
+++ b/site/profile/manifests/puppetserver.pp
@@ -1,8 +1,22 @@
 # @summary Configure puppetserver
 #
+# @param manage_firewall Manage the puppetserver firewall configuration
+#
 # @example
 #   include profile::puppetserver
-class profile::puppetserver {
+class profile::puppetserver (
+  Boolean $manage_firewall = true,
+) {
+  if $manage_firewall {
+    include 'firewalld'
+
+    firewalld_service { 'puppetmaster':
+      ensure  => present,
+      zone    => 'public',
+      service => 'puppetmaster',
+    }
+  }
+
   include 'profile::puppetserver::install'
   include 'profile::puppetserver::config'
   include 'profile::puppetserver::service'

--- a/spec/puppet/sample_spec.rb
+++ b/spec/puppet/sample_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-puppet_version = ENV['PUPPET_VERSION'] || ''
-puppet_release = puppet_version.empty? ? (ENV['PUPPET_RELEASE'] || '6') : puppet_version.split('.').first
+puppet_version = ENV.fetch('PUPPET_VERSION', '')
+puppet_release = puppet_version.empty? ? ENV.fetch('PUPPET_RELEASE', '7') : puppet_version.split('.').first
 
 # Verify the physical setup of the server
 describe interface('eth0') do


### PR DESCRIPTION
* Update modules
* Use Puppet 7 by default
* Support CentOS Stream
* Support Rocky and AlmaLinux (via `EL_OS_NAME` environment variable)
* Switch to EL9 by default
* Use native ssh (to support EL9)
* Manage firewall for puppet server
* Turn up debugging output

- Closes #6
- Closes #29
- Closes #30
- Closes #31
- Closes #32
- Closes #34
- Closes #35
- Closes #37